### PR TITLE
feat(contest): PDF do contest por subdiretorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ src/client-v2-*.js
 doc/problemexamples/*.zip
 
 # Arquivos PDF temporários ou gerados em tempo de execução
-src/private/secretcontest/*.pdf
+src/private/secretcontest/
 
 # --------------------------------------
 # Ferramentas e scripts de deploy

--- a/src/admin/contest.php
+++ b/src/admin/contest.php
@@ -20,8 +20,8 @@ require 'header.php';
 
 $contest = $_SESSION["usertable"]["contestnumber"];
 
-$portuguese_contest_path = "/var/www/boca/src/private/secretcontest/contest.pdf";
-$english_contest_path = "/var/www/boca/src/private/secretcontest/contest-en.pdf";
+$portuguese_contest_path = "/var/www/boca/src/private/secretcontest/" . (int)$contest . "/contest.pdf";
+$english_contest_path = "/var/www/boca/src/private/secretcontest/" . (int)$contest . "/contest-en.pdf";
 
 if (($ct = DBContestInfo($contest)) == null) {
     ForceLoad("$loc/index.php");
@@ -109,6 +109,7 @@ if (isset($_POST["Submit3"]) && isset($_POST["penalty"]) && is_numeric($_POST["p
             if ($file_ext != "pdf") {
                 MSGError('Please upload a valid PDF file.');
             } else {
+                @mkdir(dirname($portuguese_contest_path), 0755, true);
                 if (!move_uploaded_file($temp, $portuguese_contest_path)) {
                     MSGError('Failed to upload Contest PDF.');
                 }
@@ -131,6 +132,7 @@ if (isset($_POST["Submit3"]) && isset($_POST["penalty"]) && is_numeric($_POST["p
             if ($file_ext != "pdf") {
                 MSGError('Please upload a valid PDF file.');
             } else {
+                @mkdir(dirname($english_contest_path), 0755, true);
                 if (!move_uploaded_file($temp, $english_contest_path)) {
                     MSGError('Failed to upload Contest PDF.');
                 }

--- a/src/admin/problem.php
+++ b/src/admin/problem.php
@@ -30,12 +30,13 @@ $colors_file = '/var/www/boca/src/admin/default_problem_colors.json';
 // Carrega o JSON de cores (retorna array associativo)
 $default_colors = json_decode(file_get_contents($colors_file), true);
 
-$contest_path = "/var/www/boca/src/private/secretcontest/contest.pdf";
+$contest = (int)$_SESSION["usertable"]["contestnumber"];
+$contest_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest.pdf";
 if (file_exists($contest_path) && is_readable($contest_path)) {
     echo "<br><b>Contest completo:</b> <a href=\"../downloadcontest.php\">contest.pdf</a>";
     echo "<br>";
 }
-$contest_en_path = "/var/www/boca/src/private/secretcontest/contest-en.pdf";
+$contest_en_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest-en.pdf";
 if (file_exists($contest_en_path) && is_readable($contest_en_path)) {
     echo "<br><b>Complete contest (en):</b> <a href=\"../downloadencontest.php\">contest-en.pdf</a>";
     echo "<br>";
@@ -203,9 +204,13 @@ if (isset($_POST['Submit5']) && $_POST['Submit5'] == 'Send') {
     ForceLoad('problem.php');
 }
 
-if (isset($_POST["Submit3"]) && isset($_POST["problemnumber"]) && is_numeric($_POST["problemnumber"]) &&
+if (isset($_POST["Submit3"]) && isset($_POST["problemnumber"]) &&
     isset($_POST["problemname"])) {
-    if (strpos(trim($_POST["problemname"]), ' ') !== false) {
+    $problem_number = trim($_POST["problemnumber"]);
+    if (!is_numeric($problem_number)) {
+        $_POST["confirmation"] = '';
+        MSGError('Problem number must be numeric. Use the numeric index, for example 2 for problem B.');
+    } elseif (strpos(trim($_POST["problemname"]), ' ') !== false) {
         $_POST["confirmation"] = '';
         MSGError('Problem short name cannot have spaces');
     } else {
@@ -223,11 +228,6 @@ if (isset($_POST["Submit3"]) && isset($_POST["problemnumber"]) && is_numeric($_P
                 $name = "";
             }
 
-            $problem_number = strtoupper(trim($_POST["problemnumber"]));
-            if (!is_numeric($problem_number)) {
-                MSGError('Problem number must be numeric');
-                ForceLoad('problem.php');
-            }
             $problem_number = (int)$problem_number;
 
             $problem_name = trim($_POST["problemname"]);

--- a/src/downloadcontest.php
+++ b/src/downloadcontest.php
@@ -11,8 +11,9 @@ if (!ValidSession()) {
     ForceLoad("index.php");
 }
 
+$contest = (int)$_SESSION["usertable"]["contestnumber"];
 $prob = DBGetProblems($_SESSION["usertable"]["contestnumber"]);
-$contest_path = "/var/www/boca/src/private/secretcontest/contest.pdf";
+$contest_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest.pdf";
 $is_admin = $_SESSION["usertable"]["usertype"] == "admin";
 
 if ((!$is_admin && count($prob) == 0) || !file_exists($contest_path) || !is_readable($contest_path)) {
@@ -20,7 +21,7 @@ if ((!$is_admin && count($prob) == 0) || !file_exists($contest_path) || !is_read
     ForceLoad("index.php");
 }
 
-$filePath = '/var/www/boca/src/private/secretcontest/contest.pdf';
+$filePath = $contest_path;
 
 // Verificar se o arquivo existe
 if (file_exists($filePath)) {

--- a/src/downloadencontest.php
+++ b/src/downloadencontest.php
@@ -11,8 +11,9 @@ if (!ValidSession()) {
     ForceLoad("index.php");
 }
 
+$contest = (int)$_SESSION["usertable"]["contestnumber"];
 $prob = DBGetProblems($_SESSION["usertable"]["contestnumber"]);
-$contest_path = "/var/www/boca/src/private/secretcontest/contest-en.pdf";
+$contest_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest-en.pdf";
 $is_admin = $_SESSION["usertable"]["usertype"] == "admin";
 
 if ((!$is_admin && count($prob) == 0) || !file_exists($contest_path) || !is_readable($contest_path)) {
@@ -20,7 +21,7 @@ if ((!$is_admin && count($prob) == 0) || !file_exists($contest_path) || !is_read
     ForceLoad("index.php");
 }
 
-$filePath = '/var/www/boca/src/private/secretcontest/contest-en.pdf';
+$filePath = $contest_path;
 
 // Verificar se o arquivo existe
 if (file_exists($filePath)) {

--- a/src/team/problem.php
+++ b/src/team/problem.php
@@ -24,12 +24,13 @@ if (($ct = DBContestInfo($_SESSION["usertable"]["contestnumber"])) == null) {
 ?>
 
 <?php
+$contest = (int)$_SESSION["usertable"]["contestnumber"];
 $prob = DBGetProblems($_SESSION["usertable"]["contestnumber"]);
-$contest_path = "/var/www/boca/src/private/secretcontest/contest.pdf";
+$contest_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest.pdf";
 if (count($prob) != 0 && file_exists($contest_path) && is_readable($contest_path)) {
     echo "<br><b>Contest completo:</b> <a href=\"../downloadcontest.php\">contest.pdf</a>";
 }
-$contest_en_path = "/var/www/boca/src/private/secretcontest/contest-en.pdf";
+$contest_en_path = "/var/www/boca/src/private/secretcontest/{$contest}/contest-en.pdf";
 if (count($prob) != 0 && file_exists($contest_en_path) && is_readable($contest_en_path)) {
     echo "<br><b>Complete contest (en):</b> <a href=\"../downloadencontest.php\">contest-en.pdf</a>";
 }


### PR DESCRIPTION
Antes, /secretcontest/contest.pdf era compartilhado entre todos os contests. Trocar de contest exigia apagar e re-subir o PDF manualmente, com risco real de exibir o PDF do contest anterior (ex: aquecimento ainda ativo durante a prova oficial).

Agora cada contest tem sua propria pasta /secretcontest/{N}/, e o upload via admin/contest.php cai automaticamente na pasta do contest ativo via mkdir defensivo. Leitura em todas as paginas usa o contest da sessao.

Inclui tambem ajuste pre-existente de validacao de problemnumber em admin/problem.php (mostra MSGError em vez de bloquear silenciosamente).

- src/admin/contest.php: paths por contest + mkdir -p antes do move_uploaded_file
- src/admin/problem.php: leitura por contest + UX da validacao problemnumber
- src/team/problem.php, src/download(en)contest.php: leitura por contest
- .gitignore: ignora /secretcontest/ inteiro (antes so *.pdf)