### PR TITLE
fix(globals): cleardir nao trava em FIFO/socket

### DIFF
--- a/src/globals.php
+++ b/src/globals.php
@@ -220,7 +220,7 @@ function cleardir($dir, $cddir = true, $secure = true, $removedir = true)
                 @rmdir($dir);
             }
         } else {
-            if ($secure && !is_link($dir)) {
+            if ($secure && !is_link($dir) && is_file($dir)) {
                 file_put_contents($dir, str_repeat('XXXXXXXXXX', 10000));
             }
             @unlink($dir);


### PR DESCRIPTION
Sem checar is_file(), cleardir() tentava file_put_contents em FIFOs/sockets encontrados em diretorios sendo limpos (caso classico: /bocajail nos autojudges). Escrita em FIFO sem leitor bloqueia indefinidamente, travando o processo PHP inteiro.

Cherry-pick manual do upstream b021050 (PR cassiopc/boca#46, rsalesc/fifo).