### PR TITLE
fix(admin/problem): corrige update de cor e preserva autojudge

### DIFF
--- a/src/admin/problem.php
+++ b/src/admin/problem.php
@@ -331,7 +331,10 @@ for ($i = 0; $i < count($prob); $i++) {
                 $param['name'] = trim($_POST["problemname" . $prob[$i]['number']]);
                 $param['fake'] = 'f';
                 $param['colorname'] = $colorname;
-                $params['color'] = $color;
+                $param['color'] = $color;
+                if (isset($prob[$i]['autojudge'])) {
+                    $param['autojudge'] = (int) $prob[$i]['autojudge'];
+                }
                 DBNewProblem($_SESSION["usertable"]["contestnumber"], $param);
             }
             ForceLoad("problem.php");


### PR DESCRIPTION
Dois bugs no handler que dispara ao clicar Update na linha de um problema:

1. Typo $params['color'] (com S) em vez de $param['color']: PHP cria a variavel $params silenciosamente e o array $param chega em DBNewProblem sem a chave color. DBNewProblem so atualiza color quando o valor e nao-vazio, entao o hex no banco fica defasado (so o colorname e atualizado, gerando inconsistencia visivel na UI: nome muda mas balao continua com a cor antiga).

2. $param['autojudge'] nao era setado. DBNewProblem usa default 0 e acaba zerando a config de autojudge do problema (Everything vira None). Mesmo bug do upstream PR cassiopc/boca#44.

Caminho de reproducao: admin clica Update na coluna Color de um problema existente. Solucao: corrigir o typo e setar autojudge a partir do valor atual do problema (lido via DBGetFullProblemData).